### PR TITLE
Fix issue for py3.11

### DIFF
--- a/fairseq/dataclass/configs.py
+++ b/fairseq/dataclass/configs.py
@@ -1126,16 +1126,16 @@ class EMAConfig(FairseqDataclass):
 
 @dataclass
 class FairseqConfig(FairseqDataclass):
-    common: CommonConfig = CommonConfig()
-    common_eval: CommonEvalConfig = CommonEvalConfig()
-    distributed_training: DistributedTrainingConfig = DistributedTrainingConfig()
-    dataset: DatasetConfig = DatasetConfig()
-    optimization: OptimizationConfig = OptimizationConfig()
-    checkpoint: CheckpointConfig = CheckpointConfig()
-    bmuf: FairseqBMUFConfig = FairseqBMUFConfig()
-    generation: GenerationConfig = GenerationConfig()
-    eval_lm: EvalLMConfig = EvalLMConfig()
-    interactive: InteractiveConfig = InteractiveConfig()
+    common: CommonConfig = field(default_factory=CommonConfig)
+    common_eval: CommonEvalConfig = field(default_factory=CommonEvalConfig)
+    distributed_training: DistributedTrainingConfig = field(default_factory=DistributedTrainingConfig)
+    dataset: DatasetConfig = field(default_factory=DatasetConfig)
+    optimization: OptimizationConfig = field(default_factory=OptimizationConfig)
+    checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
+    bmuf: FairseqBMUFConfig = field(default_factory=FairseqBMUFConfig)
+    generation: GenerationConfig = field(default_factory=GenerationConfig)
+    eval_lm: EvalLMConfig = field(default_factory=EvalLMConfig)
+    interactive: InteractiveConfig = field(default_factory=InteractiveConfig)
     model: Any = MISSING
     task: Any = None
     criterion: Any = None
@@ -1144,4 +1144,4 @@ class FairseqConfig(FairseqDataclass):
     scoring: Any = None
     bpe: Any = None
     tokenizer: Any = None
-    ema: EMAConfig = EMAConfig()
+    ema: EMAConfig = field(default_factory=EMAConfig

--- a/fairseq/dataclass/configs.py
+++ b/fairseq/dataclass/configs.py
@@ -1146,4 +1146,4 @@ class FairseqConfig(FairseqDataclass):
     scoring: Any = None
     bpe: Any = None
     tokenizer: Any = None
-    ema: EMAConfig = field(default_factory=EMAConfig
+    ema: EMAConfig = field(default_factory=EMAConfig)

--- a/fairseq/dataclass/configs.py
+++ b/fairseq/dataclass/configs.py
@@ -1128,7 +1128,9 @@ class EMAConfig(FairseqDataclass):
 class FairseqConfig(FairseqDataclass):
     common: CommonConfig = field(default_factory=CommonConfig)
     common_eval: CommonEvalConfig = field(default_factory=CommonEvalConfig)
-    distributed_training: DistributedTrainingConfig = field(default_factory=DistributedTrainingConfig)
+    distributed_training: DistributedTrainingConfig = field(
+        default_factory=DistributedTrainingConfig
+    )
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     optimization: OptimizationConfig = field(default_factory=OptimizationConfig)
     checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)

--- a/fairseq/dataclass/configs.py
+++ b/fairseq/dataclass/configs.py
@@ -1129,7 +1129,7 @@ class FairseqConfig(FairseqDataclass):
     common: CommonConfig = field(default_factory=CommonConfig)
     common_eval: CommonEvalConfig = field(default_factory=CommonEvalConfig)
     distributed_training: DistributedTrainingConfig = field(
-        default_factory=DistributedTrainingConfig
+        default_factory=DistributedTrainingConfig,
     )
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     optimization: OptimizationConfig = field(default_factory=OptimizationConfig)


### PR DESCRIPTION
The fairseq is having issues with support to py3.11, blocking our CI updates for py3.11 in ESPnet. This change shall fix the issue.

FYI: https://github.com/facebookresearch/fairseq/issues/5012

See CI issues in https://github.com/espnet/espnet/actions/runs/10564316785/job/29266444574?pr=5862